### PR TITLE
Pepino-lib version upgrade

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "express": "~4.13.1",
     "jade": "~1.11.0",
     "morgan": "~1.6.1",
-    "pepino-lib": "^1.0.16",
+    "pepino-lib": "*",
     "serve-favicon": "~2.3.0"
   }
 }


### PR DESCRIPTION
In the package.json, the pepino-lib version will point to the most recent one.